### PR TITLE
Remove languages #65

### DIFF
--- a/app/components/Room.jsx
+++ b/app/components/Room.jsx
@@ -62,7 +62,7 @@ class Room extends Component {
 
   componentWillUnmount() {
     // disconnect socket, also leaves channels, unsets listeners
-    closeSocket()
+    closeSocket(this.state.language)
   }
 
   componentDidMount() {

--- a/app/sockets.js
+++ b/app/sockets.js
@@ -12,13 +12,13 @@ export function openSocket() {
   socket = io()
 }
 
-export function closeSocket() {
-  socket.close()
+export function closeSocket(language) {
+  socket.emit('close me', language)
 }
 
 export function joinRoom(language) {
   // subscribing to language channel handled server-side
-  socket.emit('join', language)
+  socket.emit('join request', language)
   voices = synth.getVoices()
 }
 

--- a/app/sockets.js
+++ b/app/sockets.js
@@ -13,6 +13,7 @@ export function openSocket() {
 }
 
 export function closeSocket(language) {
+  // disconnecting socket handled server-side
   socket.emit('close me', language)
 }
 

--- a/index.js
+++ b/index.js
@@ -36,8 +36,19 @@ let languages = []
 io.on('connection', socket => {
   console.log('new socket ', socket.id, ' connected')
 
+  socket.on('close me', language => {
+    console.log('disconnecting socket with language ', language)
+    // if this is the only socket left in a language channel
+    if (io.sockets.adapter.rooms[language].length === 1)
+      // remove that language from state
+      languages = languages.filter(lang => lang !== language)
+    console.log('all languages on server state are: ', languages)
+    // close socket
+    socket.disconnect()
+  })
+
   // when a socket joins room
-  socket.on('join', language => {
+  socket.on('join request', language => {
     console.log('socket ', socket.id, ' joined room! lang: ', language)
     // check that language choice is not empty, and not already stored
       // ^ the first part of this check may no longer be necessary, due to the lang default bug fix


### PR DESCRIPTION
- client side socket now emits 'join request' rather than 'join' for clarity (as joining channel is handled server-side)
- client side socket now submits disconnect request ('close me') to server instead of disconnecting itself, also passes language to server
- server checks stored languages to see if language needs to be removed from state server-side (if given socket is the only socket in the channel, channel will be empty upon socket disconnect)
- server disconnects socket
closes #65 